### PR TITLE
FEAT: handle Unregistered Account / refresh Token

### DIFF
--- a/src/interfaces/dimi-api.ts
+++ b/src/interfaces/dimi-api.ts
@@ -1,6 +1,6 @@
 import { DimiUserType, Gender } from "@src/types";
 
-export interface Account {
+export interface LoginInfo {
   username: string;
   password: string;
 }

--- a/src/resources/dimi-api.ts
+++ b/src/resources/dimi-api.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 import config from "@src/config";
-import { Account, UserIdentity } from "@src/interfaces";
+import { LoginInfo, UserIdentity } from "@src/interfaces";
 
 const apiRouter = {
   getIdentity: "/users/identify",
@@ -16,7 +16,7 @@ const api = axios.create({
 });
 
 export const getIdentity = async (
-  account: Account
+  account: LoginInfo
 ): Promise<{ apiData: UserIdentity; status: number }> => {
   const { data: apiData, status } = await api.get(apiRouter.getIdentity, {
     params: account,

--- a/src/services/auth/controllers.ts
+++ b/src/services/auth/controllers.ts
@@ -1,11 +1,18 @@
 import { Request, Response } from "express";
 import { User } from "@prisma/client";
 import { HttpException } from "@src/exceptions";
-import { issue as issueToken, prisma, getIdentity } from "@src/resources";
+import {
+  issue as issueToken,
+  getTokenType,
+  verify,
+  prisma,
+  getIdentity,
+} from "@src/resources";
 import { Account } from "@src/interfaces";
 
 export const identifyUser = async (req: Request, res: Response) => {
   const body: Account = req.body;
+  let isUnregistered = false;
   try {
     if (body.username == body.password) {
       throw {
@@ -20,23 +27,39 @@ export const identifyUser = async (req: Request, res: Response) => {
 
     if (status === 200) {
       const identify =
-        (await prisma.user.findUnique({
-          where: { accountName: apiData.username },
-        })) ||
-        (await prisma.user.create({
-          data: {
-            accountName: apiData.username,
-            name: apiData.name,
-            profileImage: apiData.photofile2,
-            roles: apiData.user_type === "T" ? ["USER", "TEACHER"] : ["USER"],
-            studentNumber: apiData.studentNumber,
-            systemUid: apiData.id.toString(),
-          },
-        }));
+        (await (async () => {
+          const a = await prisma.user.findUnique({
+            where: { accountName: apiData.username },
+          });
+          if (a.studentNumber !== apiData.studentNumber) {
+            return await prisma.user.update({
+              where: { accountName: apiData.username },
+              data: {
+                studentNumber: apiData.studentNumber,
+              },
+            });
+          } else {
+            return a;
+          }
+        })()) ||
+        (await (async () => {
+          isUnregistered = true;
+          return await prisma.user.create({
+            data: {
+              accountName: apiData.username,
+              name: apiData.name,
+              profileImage: apiData.photofile2,
+              roles: apiData.user_type === "T" ? ["USER", "TEACHER"] : ["USER"],
+              studentNumber: apiData.studentNumber,
+              systemUid: apiData.id.toString(),
+            },
+          });
+        })());
 
       return res.status(200).json({
         accessToken: await issueToken(identify, false),
         refreshToken: await issueToken(identify, true),
+        isUnregistered,
       });
     }
   } catch (e) {
@@ -50,5 +73,18 @@ export const identifyUser = async (req: Request, res: Response) => {
 };
 
 export const refreshAccessToken = async (req: Request, res: Response) => {
-  //토큰 재발급 로직
+  const { token: refreshToken } = req;
+  if (!refreshToken)
+    throw new HttpException(400, "리프레시 토큰이 전달되지 않았습니다.");
+
+  const tokenType = await getTokenType(refreshToken);
+  if (tokenType !== "REFRESH")
+    throw new HttpException(400, "리프레시 토큰이 아닙니다.");
+
+  const payload = await verify(refreshToken);
+  const identity = await prisma.user.findUnique({ where: { id: payload.id } });
+  res.json({
+    accessToken: await issueToken(identity, false),
+    refreshToken: await issueToken(identity, true),
+  });
 };

--- a/src/services/auth/index.ts
+++ b/src/services/auth/index.ts
@@ -18,7 +18,7 @@ export default createService({
       },
     },
     {
-      method: "get",
+      method: "post",
       path: "/refresh",
       handler: controllers.refreshAccessToken,
       needAuth: false,

--- a/src/services/auth/index.ts
+++ b/src/services/auth/index.ts
@@ -18,7 +18,7 @@ export default createService({
       },
     },
     {
-      method: "post",
+      method: "get",
       path: "/refresh",
       handler: controllers.refreshAccessToken,
       needAuth: false,


### PR DESCRIPTION
- `isUnregistered: boolean` 속성으로 최초 로그인 여부를 전달합니다.
- `auth/refresh` 엔드포인트에 `Authorization` Header로 Refresh Token을 넘기면 token이 갱신됩니다.